### PR TITLE
Fix: Preconditions/postconditions rendering as [object]

### DIFF
--- a/source-templates/methodologies/business/uc_advanced.hbs
+++ b/source-templates/methodologies/business/uc_advanced.hbs
@@ -39,14 +39,14 @@
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/methodologies/business/uc_normal.hbs
+++ b/source-templates/methodologies/business/uc_normal.hbs
@@ -28,14 +28,14 @@
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/methodologies/developer/uc_advanced.hbs
+++ b/source-templates/methodologies/developer/uc_advanced.hbs
@@ -55,14 +55,14 @@
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/methodologies/developer/uc_normal.hbs
+++ b/source-templates/methodologies/developer/uc_normal.hbs
@@ -24,14 +24,14 @@
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/methodologies/feature/uc_advanced.hbs
+++ b/source-templates/methodologies/feature/uc_advanced.hbs
@@ -46,14 +46,14 @@
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/methodologies/feature/uc_normal.hbs
+++ b/source-templates/methodologies/feature/uc_normal.hbs
@@ -27,14 +27,14 @@
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/methodologies/tester/uc_advanced.hbs
+++ b/source-templates/methodologies/tester/uc_advanced.hbs
@@ -47,18 +47,17 @@
 {{/each}}
 
 {{/if}}
-
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/methodologies/tester/uc_normal.hbs
+++ b/source-templates/methodologies/tester/uc_normal.hbs
@@ -25,14 +25,14 @@
 {{#if preconditions}}
 ## Preconditions
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 ## Postconditions
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}

--- a/source-templates/scenarios/scenario.hbs
+++ b/source-templates/scenarios/scenario.hbs
@@ -31,14 +31,14 @@
 {{#if preconditions}}
 **Preconditions:**
 {{#each preconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}
 {{#if postconditions}}
 **Postconditions:**
 {{#each postconditions}}
-- {{this}}
+- {{this.text}}{{#if this.use_case_reference}} (see [{{this.use_case_reference}}](../{{this.use_case_reference}}.md)){{/if}}
 {{/each}}
 
 {{/if}}


### PR DESCRIPTION
Fixes the bug where preconditions and postconditions were displaying as `[object]` instead of their text content.

## Changes
- Fixed all 8 methodology templates (business, developer, feature, tester - normal & advanced)
- Fixed scenario template
- Now properly accesses `.text` property on condition objects
- Added support for displaying use case references in conditions

## Testing
- Created test use case in /tmp with preconditions/postconditions
- Verified fix works correctly - now shows actual text instead of `[object]`

Closes #33 