### PR TITLE
Feature: Expose manual use-case status to templates + tests/docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussions
-    url: https://github.com/Guillaumecoi/MD-usecase-manager/discussions
+    url: https://github.com/Guillaumecoi/MUCM/discussions
     about: Ask questions and discuss ideas with the community
   - name: Security Vulnerability
-    url: https://github.com/Guillaumecoi/MD-usecase-manager/security/advisories/new
+    url: https://github.com/Guillaumecoi/MUCM/security/advisories/new
     about: Report security vulnerabilities privately

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ By participating in this project, you agree to maintain a respectful and inclusi
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/Guillaumecoi/MD-usecase-manager.git
-   cd MD-usecase-manager
+   git clone https://github.com/Guillaumecoi/MUCM.git
+   cd MUCM
    ```
 
 2. **Build the project**

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 - **Keeping it structured manually is painful** - consistent formatting across dozens of use cases is tedious
 - **Vendor lock-in** - your documentation is trapped in proprietary systems
 
-### The Solution
-Edit TOML files (just like config files), commit to git, and get:
+git clone https://github.com/Guillaumecoi/MUCM
+cd MUCM
 - **Customizable templates without coding** - Handlebars templates you can edit to format output exactly how you want
 - **Version-controlled source of truth** in your repo, no servers, no online services, zero barriers
 - **Auto-generated test scaffolding** with safe zones so your code survives regeneration

--- a/docs/guides/customization/available-helpers.md
+++ b/docs/guides/customization/available-helpers.md
@@ -177,6 +177,48 @@ If parent has steps 1-5, and exception extends at step 4 returning to step 2:
 
 ---
 
+## Use-case Fields & Helpers
+
+Fields and small helpers exposed to use-case templates.
+
+### `aggregated_status` (Field)
+
+**Usage:** `{{aggregated_status}}`
+**Description:** The human-friendly display name of the use-case status (derived from the `UseCase` object). Note: `UseCase.status` was made manual; this field simply reflects that value for templates.
+**Returns:** Uppercase status string (e.g., `PLANNED`, `IN_PROGRESS`, `IMPLEMENTED`).
+
+**Example:**
+```handlebars
+Status: {{aggregated_status}}
+```
+
+### `aggregated_status_emoji` (Field)
+
+**Usage:** `{{aggregated_status_emoji}}`
+**Description:** Emoji-only representation of the use-case status injected into the template data. Useful for compact badges.
+**Returns:** A short emoji (e.g., `📋`, `🔄`, `⚡`, `✅`, `🚀`, `⚠️`).
+
+**Example:**
+```handlebars
+Status: {{aggregated_status_emoji}} {{aggregated_status}}
+```
+
+### `status_emoji` (Helper)
+
+**Usage:** `{{status_emoji status_string}}` or `{{status_emoji}}` (reads `aggregated_status` from context when no param provided)
+**Description:** Handlebars helper that converts a status string (or the context `aggregated_status`) into its emoji. Useful when you only have a status string and want the emoji mapping inside templates.
+**Returns:** Emoji string for the given status.
+
+**Example:**
+```handlebars
+{{status_emoji aggregated_status}}
+{{status_emoji "implemented"}}
+```
+
+**Notes:** The helper accepts display names or common status strings (case-insensitive). If the helper is called without a parameter it will use the `aggregated_status` field from the template context.
+
+---
+
 ## Formatting Helpers
 
 Helpers for text transformation and formatting.

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/category_overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/category_overview.hbs
@@ -11,12 +11,46 @@ This category contains **{{total_use_cases}}** use case{{#if (gt total_use_cases
 - **Last Updated:** {{date_format last_updated}}
 
 ## Use Cases
-
 {{#if use_cases}}
-| ID | Title | Description | Status | Priority | Main | Alternative | Exception | Extension | Last Updated | Views |
-|---|---|---|---|---|---:|---:|---:|---:|---|---|
+{{#if status_counts}}
+## Status Distribution
+
+| Status | Count |
+|---:|:---|
+{{#each status_counts}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
+{{/each}}
+
+{{/if}}
+
+## Scenarios
+
+Overall scenario counts across this category:
+
+| Type | Count |
+|---:|:---|
+| Main | {{scenario_totals.main}} |
+| Alternative | {{scenario_totals.alternative}} |
+| Exception | {{scenario_totals.exception}} |
+| Extension | {{scenario_totals.extension}} |
+
+
+{{#if scenario_status_counts}}
+## Scenario Status Distribution
+
+| Status | Count |
+|---:|:---|
+{{#each scenario_status_counts}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
+{{/each}}
+
+{{/if}}
+
+
+| ID | Title | Status | Priority | Last Updated |
+|---|---|---|---|---|
 {{#each use_cases}}
-| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{scenario_counts.main}} | {{scenario_counts.alternative}} | {{scenario_counts.exception}} | {{scenario_counts.extension}} | {{date_format last_updated}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{date_format last_updated}} |
 {{/each}}
 
 ---

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/category_overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/category_overview.hbs
@@ -10,21 +10,15 @@ This category contains **{{total_use_cases}}** use case{{#if (gt total_use_cases
 
 ## Use Cases
 
+{{#if use_cases}}
+| ID | Title | Description | Status | Priority | Views |
+|---|---|---|---|---|---|
 {{#each use_cases}}
-### [{{id}}: {{title}}](./{{id}}/README.md)
-
-**Status:** {{aggregated_status}} | **Priority:** {{priority}}
-
-{{#if description}}{{description}}{{/if}}
-
-{{#if views}}
-**Available Views:** {{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}
-{{/if}}
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
+{{/each}}
 
 ---
 
-{{/each}}
-
-{{#unless use_cases}}
+{{else}}
 *No use cases in this category yet.*
-{{/unless}}
+{{/if}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/category_overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/category_overview.hbs
@@ -8,13 +8,15 @@
 
 This category contains **{{total_use_cases}}** use case{{#if (gt total_use_cases 1)}}s{{/if}}.
 
+- **Last Updated:** {{date_format last_updated}}
+
 ## Use Cases
 
 {{#if use_cases}}
-| ID | Title | Description | Status | Priority | Views |
-|---|---|---|---|---|---|
+| ID | Title | Description | Status | Priority | Main | Alternative | Exception | Extension | Last Updated | Views |
+|---|---|---|---|---|---:|---:|---:|---:|---|---|
 {{#each use_cases}}
-| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{scenario_counts.main}} | {{scenario_counts.alternative}} | {{scenario_counts.exception}} | {{scenario_counts.extension}} | {{date_format last_updated}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
 {{/each}}
 
 ---

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_advanced.hbs
@@ -52,7 +52,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Business Analysis: {{title}}
 
 **Use Case ID:** {{id}}  
-**Analysis Status:** {{status}}  
+**Analysis Status:** {{aggregated_status}}  
 **Business Priority:** {{priority}}  
 **Last Updated:** {{date_format metadata.updated_at}}
 

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_advanced.hbs
@@ -50,6 +50,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Business Analysis: {{title}}
 
-**Use Case ID:** {{id}} | **Status:** {{status}} | **Priority:** {{priority}} | **Analysis Date:** {{date_format metadata.created_at}}
+**Use Case ID:** {{id}} | **Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Analysis Date:** {{date_format metadata.created_at}}
 ---
 
 {{#if core.description}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_normal.hbs
@@ -40,6 +40,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/business/uc_normal.hbs
@@ -42,7 +42,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_advanced.hbs
@@ -66,6 +66,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Technical Specification: {{title}}
 
 **Use Case ID:** {{id}}  
-**Implementation Status:** {{status}}  
+**Implementation Status:** {{aggregated_status}}  
 **Development Priority:** {{priority}}  
 **Specification Date:** {{date_format metadata.created_at}}
 

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_advanced.hbs
@@ -68,7 +68,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Technical Specification: {{title}}
 
-**Use Case ID:** {{id}} | **Status:** {{status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
+**Use Case ID:** {{id}} | **Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
 
 {{#if description}}
 ## Technical Overview

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_normal.hbs
@@ -35,6 +35,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/developer/uc_normal.hbs
@@ -37,7 +37,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_advanced.hbs
@@ -57,6 +57,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 
 {{#if use_case_references}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_advanced.hbs
@@ -59,7 +59,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Feature Proposal: {{title}}
 
 **ID:** {{id}}  
-**Status:** {{status}}  
+**Status:** {{aggregated_status}}  
 **Priority:** {{priority}}  
 **Created:** {{date_format metadata.created_at}}
 

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_normal.hbs
@@ -38,6 +38,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 
 {{#if use_case_references}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Feature: {{title}}
 
-**ID:** {{id}} | **Status:** {{status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
+**ID:** {{id}} | **Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
 
 {{#if description}}
 ## Summary

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/feature/uc_normal.hbs
@@ -40,7 +40,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Test Specification: {{title}}
 
 **Use Case ID:** {{id}}  
-**Test Status:** {{status}}  
+**Test Status:** {{aggregated_status}}  
 **Test Priority:** {{priority}}  
 **Test Plan Date:** {{date_format metadata.created_at}}
 

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_advanced.hbs
@@ -63,7 +63,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if test_data_requirements}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_advanced.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_advanced.hbs
@@ -61,6 +61,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if test_data_requirements}}
 ## Test Data Requirements

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Test Specification: {{title}}
 
-**Use Case ID:** {{id}} | **Test Status:** {{status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
+**Use Case ID:** {{id}} | **Test Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
 
 {{#if description}}
 ## Test Overview

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_normal.hbs
@@ -36,6 +36,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if test_data_requirements}}
 ## Test Data Requirements

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_normal.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/methodologies/tester/uc_normal.hbs
@@ -38,7 +38,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if test_data_requirements}}

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/overview.hbs
@@ -32,6 +32,18 @@ Overall scenario counts across all use cases:
 | Extension | {{scenario_totals.extension}} |
 
 
+{{#if scenario_status_counts}}
+## Scenario Status Distribution
+
+| Status | Count |
+|---:|:---|
+{{#each scenario_status_counts}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
+{{/each}}
+
+{{/if}}
+
+
 ## Categories
 
 Below is a compact overview of each category with its use cases (status badges included).

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/overview.hbs
@@ -1,26 +1,41 @@
+<!-- prettier overview with status badges and per-category compact tables -->
 # Use Cases Overview
 
 **Project:** {{project_name}}
 
 ## Summary
+
 - **Total Use Cases:** {{total_use_cases}}
 - **Total Categories:** {{total_categories}}
 
 {{#if status_counts}}
 ## Status Distribution
+
+| Status | Count |
+|---:|:---|
 {{#each status_counts}}
-- **{{@key}}:** {{this}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
 {{/each}}
+
 {{/if}}
 
 ## Categories
 
+Below is a compact overview of each category with its use cases (status badges included).
+
 {{#each categories}}
+
 ### [{{category_name}}](./{{category_path}}/README.md)
 
-{{#if use_case_count}}**Use Cases:** {{use_case_count}}{{/if}}
+- **Use Cases:** {{use_case_count}}
 
 {{#if description}}{{description}}{{/if}}
+
+| ID | Title | Status | Priority |
+|---|---|---|---|
+{{#each use_cases}}
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} |
+{{/each}}
 
 ---
 

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/overview.hbs
@@ -7,6 +7,7 @@
 
 - **Total Use Cases:** {{total_use_cases}}
 - **Total Categories:** {{total_categories}}
+ - **Last Updated:** {{date_format last_updated}}
 
 {{#if status_counts}}
 ## Status Distribution
@@ -18,6 +19,18 @@
 {{/each}}
 
 {{/if}}
+
+## Scenarios
+
+Overall scenario counts across all use cases:
+
+| Type | Count |
+|---:|:---|
+| Main | {{scenario_totals.main}} |
+| Alternative | {{scenario_totals.alternative}} |
+| Exception | {{scenario_totals.exception}} |
+| Extension | {{scenario_totals.extension}} |
+
 
 ## Categories
 
@@ -31,10 +44,10 @@ Below is a compact overview of each category with its use cases (status badges i
 
 {{#if description}}{{description}}{{/if}}
 
-| ID | Title | Status | Priority |
-|---|---|---|---|
+| ID | Title | Status | Priority | Last Updated |
+|---|---|---|---|---|
 {{#each use_cases}}
-| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} |
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{date_format last_updated}} |
 {{/each}}
 
 ---

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/use_case_overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/use_case_overview.hbs
@@ -34,6 +34,10 @@ This use case has multiple methodology views available:
 - **[{{methodology}} ({{level}})](./{{../id}}-{{methodology}}-{{level}}.md)** - {{#if (eq methodology "developer")}}Detailed technical specifications for developers{{else if (eq methodology "tester")}}Comprehensive testing scenarios and acceptance criteria{{else if (eq methodology "business")}}Business value analysis and stakeholder requirements{{else if (eq methodology "feature")}}User stories and agile workflow details{{else}}{{methodology}} perspective{{/if}}
 {{/each}}
 
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 
 ---

--- a/examples/ecommerce-demo/.config/.mucm/template-assets/use_case_overview.hbs
+++ b/examples/ecommerce-demo/.config/.mucm/template-assets/use_case_overview.hbs
@@ -36,7 +36,15 @@ This use case has multiple methodology views available:
 
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 

--- a/examples/ecommerce-demo/README.md
+++ b/examples/ecommerce-demo/README.md
@@ -260,6 +260,6 @@ Want to see more? Check out:
 - [CLI Reference](../../docs/guides/cli/cli-reference.md) — All commands
 - [Template Customization](../../docs/guides/customization/template-customization.md) — Make it yours
 
-**Questions?** Join the [discussions](https://github.com/Guillaumecoi/MD-usecase-manager/discussions) · **Found a bug?** [Open an issue](https://github.com/Guillaumecoi/MD-usecase-manager/issues) · **Want to contribute?** PRs welcome!
+**Questions?** Join the [discussions](https://github.com/Guillaumecoi/MUCM/discussions) · **Found a bug?** [Open an issue](https://github.com/Guillaumecoi/MUCM/issues) · **Want to contribute?** PRs welcome!
 
 **Now go automate your documentation. You'll never go back.**

--- a/examples/ecommerce-demo/docs/use-cases/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/README.md
@@ -1,19 +1,35 @@
+<!-- prettier overview with status badges and per-category compact tables -->
 # Use Cases Overview
 
 **Project:** My Project
 
 ## Summary
+
 - **Total Use Cases:** 2
 - **Total Categories:** 1
+
+## Status Distribution
+
+| Status | Count |
+|---:|:---|
+| 📋 **PLANNED** | 2 |
 
 
 ## Categories
 
+Below is a compact overview of each category with its use cases (status badges included).
+
+
 ### [Authentication](./authentication/README.md)
 
-**Use Cases:** 2
+- **Use Cases:** 2
 
 
+
+| ID | Title | Status | Priority |
+|---|---|---|---|
+| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | 📋 PLANNED | CRITICAL |
+| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | 📋 PLANNED | HIGH |
 
 ---
 

--- a/examples/ecommerce-demo/docs/use-cases/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/README.md
@@ -28,6 +28,16 @@ Overall scenario counts across all use cases:
 | Extension | 0 |
 
 
+## Scenario Status Distribution
+
+| Status | Count |
+|---:|:---|
+| 🚀 **DEPLOYED** | 2 |
+| ⚡ **IMPLEMENTED** | 2 |
+| 📋 **PLANNED** | 2 |
+
+
+
 ## Categories
 
 Below is a compact overview of each category with its use cases (status badges included).

--- a/examples/ecommerce-demo/docs/use-cases/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/README.md
@@ -7,12 +7,25 @@
 
 - **Total Use Cases:** 2
 - **Total Categories:** 1
+ - **Last Updated:** 07/12/2025
 
 ## Status Distribution
 
 | Status | Count |
 |---:|:---|
 | 📋 **PLANNED** | 2 |
+
+
+## Scenarios
+
+Overall scenario counts across all use cases:
+
+| Type | Count |
+|---:|:---|
+| Main | 2 |
+| Alternative | 1 |
+| Exception | 3 |
+| Extension | 0 |
 
 
 ## Categories
@@ -26,10 +39,10 @@ Below is a compact overview of each category with its use cases (status badges i
 
 
 
-| ID | Title | Status | Priority |
-|---|---|---|---|
-| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | 📋 PLANNED | CRITICAL |
-| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | 📋 PLANNED | HIGH |
+| ID | Title | Status | Priority | Last Updated |
+|---|---|---|---|---|
+| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | 📋 PLANNED | CRITICAL | 07/12/2025 |
+| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | 📋 PLANNED | HIGH | 07/12/2025 |
 
 ---
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/README.md
@@ -11,6 +11,12 @@ This category contains **2** use cases.
 - **Last Updated:** 07/12/2025
 
 ## Use Cases
+## Status Distribution
+
+| Status | Count |
+|---:|:---|
+| 📋 **PLANNED** | 2 |
+
 
 ## Scenarios
 
@@ -23,6 +29,14 @@ Overall scenario counts across this category:
 | Exception | 3 |
 | Extension | 0 |
 
+
+## Scenario Status Distribution
+
+| Status | Count |
+|---:|:---|
+| 🚀 **DEPLOYED** | 2 |
+| ⚡ **IMPLEMENTED** | 2 |
+| 📋 **PLANNED** | 2 |
 
 
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/README.md
@@ -12,10 +12,24 @@ This category contains **2** use cases.
 
 ## Use Cases
 
-| ID | Title | Description | Status | Priority | Main | Alternative | Exception | Extension | Last Updated | Views |
-|---|---|---|---|---|---:|---:|---:|---:|---|---|
-| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | Allow registered users to authenticate and access their accounts by providing email and password. The system validates credentials, creates a session, and redirects users to their personalized dashboard or previous page. | 📋 PLANNED | CRITICAL | 1 | 0 | 0 | 0 | 07/12/2025 | developer-normal, tester-advanced |
-| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | Allow new users to create an account on the e-commerce platform by providing email, password, and basic profile information. The system validates input, checks for existing accounts, creates the user record, and sends a verification email. | 📋 PLANNED | HIGH | 1 | 1 | 3 | 0 | 07/12/2025 | developer-advanced, tester-advanced |
+## Scenarios
+
+Overall scenario counts across this category:
+
+| Type | Count |
+|---:|:---|
+| Main | 2 |
+| Alternative | 1 |
+| Exception | 3 |
+| Extension | 0 |
+
+
+
+
+| ID | Title | Status | Priority | Last Updated |
+|---|---|---|---|---|
+| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | 📋 PLANNED | CRITICAL | 07/12/2025 |
+| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | 📋 PLANNED | HIGH | 07/12/2025 |
 
 ---
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/README.md
@@ -10,24 +10,10 @@ This category contains **2** use cases.
 
 ## Use Cases
 
-### [UC-AUTH-002: User Login](./UC-AUTH-002/README.md)
-
-**Status:** DEPLOYED | **Priority:** CRITICAL
-
-Allow registered users to authenticate and access their accounts by providing email and password. The system validates credentials, creates a session, and redirects users to their personalized dashboard or previous page.
-
-**Available Views:** developer-normal, tester-advanced
+| ID | Title | Description | Status | Priority | Views |
+|---|---|---|---|---|---|
+| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | Allow registered users to authenticate and access their accounts by providing email and password. The system validates credentials, creates a session, and redirects users to their personalized dashboard or previous page. | 📋 PLANNED | CRITICAL | developer-normal, tester-advanced |
+| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | Allow new users to create an account on the e-commerce platform by providing email, password, and basic profile information. The system validates input, checks for existing accounts, creates the user record, and sends a verification email. | 📋 PLANNED | HIGH | developer-advanced, tester-advanced |
 
 ---
-
-### [UC-AUTH-001: User Registration](./UC-AUTH-001/README.md)
-
-**Status:** PLANNED | **Priority:** HIGH
-
-Allow new users to create an account on the e-commerce platform by providing email, password, and basic profile information. The system validates input, checks for existing accounts, creates the user record, and sends a verification email.
-
-**Available Views:** developer-advanced, tester-advanced
-
----
-
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/README.md
@@ -8,12 +8,14 @@
 
 This category contains **2** use cases.
 
+- **Last Updated:** 07/12/2025
+
 ## Use Cases
 
-| ID | Title | Description | Status | Priority | Views |
-|---|---|---|---|---|---|
-| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | Allow registered users to authenticate and access their accounts by providing email and password. The system validates credentials, creates a session, and redirects users to their personalized dashboard or previous page. | 📋 PLANNED | CRITICAL | developer-normal, tester-advanced |
-| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | Allow new users to create an account on the e-commerce platform by providing email, password, and basic profile information. The system validates input, checks for existing accounts, creates the user record, and sends a verification email. | 📋 PLANNED | HIGH | developer-advanced, tester-advanced |
+| ID | Title | Description | Status | Priority | Main | Alternative | Exception | Extension | Last Updated | Views |
+|---|---|---|---|---|---:|---:|---:|---:|---|---|
+| [UC-AUTH-002](./UC-AUTH-002/README.md) | User Login | Allow registered users to authenticate and access their accounts by providing email and password. The system validates credentials, creates a session, and redirects users to their personalized dashboard or previous page. | 📋 PLANNED | CRITICAL | 1 | 0 | 0 | 0 | 07/12/2025 | developer-normal, tester-advanced |
+| [UC-AUTH-001](./UC-AUTH-001/README.md) | User Registration | Allow new users to create an account on the e-commerce platform by providing email, password, and basic profile information. The system validates input, checks for existing accounts, creates the user record, and sends a verification email. | 📋 PLANNED | HIGH | 1 | 1 | 3 | 0 | 07/12/2025 | developer-advanced, tester-advanced |
 
 ---
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/README.md
@@ -30,6 +30,10 @@ This use case has multiple methodology views available:
 - **[developer (advanced)](./UC-AUTH-001-developer-advanced.md)** - Detailed technical specifications for developers
 - **[tester (advanced)](./UC-AUTH-001-tester-advanced.md)** - Comprehensive testing scenarios and acceptance criteria
 
+## Scenarios (quick overview)
+
+**Scenarios:** [UC-AUTH-001-S01]()  deployed, [UC-AUTH-001-S02]()  planned, [UC-AUTH-001-S03]()  implemented, [UC-AUTH-001-S04]()  implemented, [UC-AUTH-001-S05]()  planned
+
 ## UC-AUTH-001-S01 - Successful User Registration
 
 **Primary Actor:** [Guest User](../../../actors/guest-guest-user.md)

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/README.md
@@ -32,7 +32,13 @@ This use case has multiple methodology views available:
 
 ## Scenarios (quick overview)
 
-**Scenarios:** [UC-AUTH-001-S01]()  deployed, [UC-AUTH-001-S02]()  planned, [UC-AUTH-001-S03]()  implemented, [UC-AUTH-001-S04]()  implemented, [UC-AUTH-001-S05]()  planned
+| ID | Title | Status |
+|---|---|---|
+| [UC-AUTH-001-S01]() | Successful User Registration | 📋 deployed |
+| [UC-AUTH-001-S02]() | Registration with Social Login | 📋 planned |
+| [UC-AUTH-001-S03]() | Email Already Registered | 📋 implemented |
+| [UC-AUTH-001-S04]() | Invalid password | 📋 implemented |
+| [UC-AUTH-001-S05]() | Email Service Unavailable | 📋 planned |
 
 ## UC-AUTH-001-S01 - Successful User Registration
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/README.md
@@ -1,6 +1,6 @@
 # Use Case: UC-AUTH-001: User Registration
 
-**Status:**  | **Priority:** High
+**Status:** PLANNED | **Priority:** High
 
 **Category:** Authentication
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-developer-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-developer-advanced.md
@@ -1,7 +1,7 @@
 # Technical Specification: User Registration
 
 **Use Case ID:** UC-AUTH-001  
-**Implementation Status:**   
+**Implementation Status:** PLANNED  
 **Development Priority:** High  
 **Specification Date:** 03/12/2025
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-developer-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-developer-advanced.md
@@ -55,7 +55,13 @@ Allow new users to create an account on the e-commerce platform by providing ema
 
 ## Scenarios (quick overview)
 
-**Scenarios:** [UC-AUTH-001-S01]()  deployed, [UC-AUTH-001-S02]()  planned, [UC-AUTH-001-S03]()  implemented, [UC-AUTH-001-S04]()  implemented, [UC-AUTH-001-S05]()  planned
+| ID | Title | Status |
+|---|---|---|
+| [UC-AUTH-001-S01]() | Successful User Registration | 📋 deployed |
+| [UC-AUTH-001-S02]() | Registration with Social Login | 📋 planned |
+| [UC-AUTH-001-S03]() | Email Already Registered | 📋 implemented |
+| [UC-AUTH-001-S04]() | Invalid password | 📋 implemented |
+| [UC-AUTH-001-S05]() | Email Service Unavailable | 📋 planned |
 
 ## UC-AUTH-001-S01 - Successful User Registration
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-developer-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-developer-advanced.md
@@ -53,6 +53,10 @@ Allow new users to create an account on the e-commerce platform by providing ema
 - Session created and stored in cache
 - User can access basic platform features (but not checkout until verified)
 
+## Scenarios (quick overview)
+
+**Scenarios:** [UC-AUTH-001-S01]()  deployed, [UC-AUTH-001-S02]()  planned, [UC-AUTH-001-S03]()  implemented, [UC-AUTH-001-S04]()  implemented, [UC-AUTH-001-S05]()  planned
+
 ## UC-AUTH-001-S01 - Successful User Registration
 
 **Primary Actor:** [Guest User](../../../actors/guest-guest-user.md)

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-tester-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-tester-advanced.md
@@ -35,6 +35,10 @@
 - Session created and stored in cache
 - User can access basic platform features (but not checkout until verified)
 
+## Scenarios (quick overview)
+
+**Scenarios:** [UC-AUTH-001-S01]()  deployed, [UC-AUTH-001-S02]()  planned, [UC-AUTH-001-S03]()  implemented, [UC-AUTH-001-S04]()  implemented, [UC-AUTH-001-S05]()  planned
+
 ## UC-AUTH-001-S01 - Successful User Registration
 
 **Primary Actor:** [Guest User](../../../actors/guest-guest-user.md)

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-tester-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-tester-advanced.md
@@ -37,7 +37,13 @@
 
 ## Scenarios (quick overview)
 
-**Scenarios:** [UC-AUTH-001-S01]()  deployed, [UC-AUTH-001-S02]()  planned, [UC-AUTH-001-S03]()  implemented, [UC-AUTH-001-S04]()  implemented, [UC-AUTH-001-S05]()  planned
+| ID | Title | Status |
+|---|---|---|
+| [UC-AUTH-001-S01]() | Successful User Registration | 📋 deployed |
+| [UC-AUTH-001-S02]() | Registration with Social Login | 📋 planned |
+| [UC-AUTH-001-S03]() | Email Already Registered | 📋 implemented |
+| [UC-AUTH-001-S04]() | Invalid password | 📋 implemented |
+| [UC-AUTH-001-S05]() | Email Service Unavailable | 📋 planned |
 
 ## UC-AUTH-001-S01 - Successful User Registration
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-tester-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-001/UC-AUTH-001-tester-advanced.md
@@ -1,7 +1,7 @@
 # Test Specification: User Registration
 
 **Use Case ID:** UC-AUTH-001  
-**Test Status:**   
+**Test Status:** PLANNED  
 **Test Priority:** High  
 **Test Plan Date:** 03/12/2025
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/README.md
@@ -1,6 +1,6 @@
 # Use Case: UC-AUTH-002: User Login
 
-**Status:**  | **Priority:** Critical
+**Status:** PLANNED | **Priority:** Critical
 
 **Category:** Authentication
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/README.md
@@ -33,7 +33,9 @@ This use case has multiple methodology views available:
 
 ## Scenarios (quick overview)
 
-**Scenarios:** [UC-AUTH-002-S01]()  deployed
+| ID | Title | Status |
+|---|---|---|
+| [UC-AUTH-002-S01]() | Successful Login with Email and Password | 📋 deployed |
 
 ## UC-AUTH-002-S01 - Successful Login with Email and Password
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/README.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/README.md
@@ -31,6 +31,10 @@ This use case has multiple methodology views available:
 - **[developer (normal)](./UC-AUTH-002-developer-normal.md)** - Detailed technical specifications for developers
 - **[tester (advanced)](./UC-AUTH-002-tester-advanced.md)** - Comprehensive testing scenarios and acceptance criteria
 
+## Scenarios (quick overview)
+
+**Scenarios:** [UC-AUTH-002-S01]()  deployed
+
 ## UC-AUTH-002-S01 - Successful Login with Email and Password
 
 **Primary Actor:** [Maria Garcia](../../../actors/customer-support-agent-maria-garcia.md)

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-developer-normal.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-developer-normal.md
@@ -27,6 +27,10 @@ Allow registered users to authenticate and access their accounts by providing em
 - User redirected to dashboard or previous page
 - Last login timestamp updated in database
 
+## Scenarios (quick overview)
+
+**Scenarios:** [UC-AUTH-002-S01]()  deployed
+
 ## UC-AUTH-002-S01 - Successful Login with Email and Password
 
 **Primary Actor:** [Maria Garcia](../../../actors/customer-support-agent-maria-garcia.md)

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-developer-normal.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-developer-normal.md
@@ -29,7 +29,9 @@ Allow registered users to authenticate and access their accounts by providing em
 
 ## Scenarios (quick overview)
 
-**Scenarios:** [UC-AUTH-002-S01]()  deployed
+| ID | Title | Status |
+|---|---|---|
+| [UC-AUTH-002-S01]() | Successful Login with Email and Password | 📋 deployed |
 
 ## UC-AUTH-002-S01 - Successful Login with Email and Password
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-developer-normal.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-developer-normal.md
@@ -1,6 +1,6 @@
 # Technical Specification: User Login
 
-**Use Case ID:** UC-AUTH-002 | **Status:**  | **Priority:** Critical | **Created:** 07/12/2025
+**Use Case ID:** UC-AUTH-002 | **Status:** PLANNED | **Priority:** Critical | **Created:** 07/12/2025
 
 ## Technical Overview
 Allow registered users to authenticate and access their accounts by providing email and password. The system validates credentials, creates a session, and redirects users to their personalized dashboard or previous page.

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-tester-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-tester-advanced.md
@@ -37,7 +37,9 @@
 
 ## Scenarios (quick overview)
 
-**Scenarios:** [UC-AUTH-002-S01]()  deployed
+| ID | Title | Status |
+|---|---|---|
+| [UC-AUTH-002-S01]() | Successful Login with Email and Password | 📋 deployed |
 
 ## UC-AUTH-002-S01 - Successful Login with Email and Password
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-tester-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-tester-advanced.md
@@ -1,7 +1,7 @@
 # Test Specification: User Login
 
 **Use Case ID:** UC-AUTH-002  
-**Test Status:**   
+**Test Status:** PLANNED  
 **Test Priority:** Critical  
 **Test Plan Date:** 07/12/2025
 

--- a/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-tester-advanced.md
+++ b/examples/ecommerce-demo/docs/use-cases/authentication/UC-AUTH-002/UC-AUTH-002-tester-advanced.md
@@ -35,6 +35,10 @@
 - User redirected to dashboard or previous page
 - Last login timestamp updated in database
 
+## Scenarios (quick overview)
+
+**Scenarios:** [UC-AUTH-002-S01]()  deployed
+
 ## UC-AUTH-002-S01 - Successful Login with Email and Password
 
 **Primary Actor:** [Maria Garcia](../../../actors/customer-support-agent-maria-garcia.md)

--- a/source-templates/category_overview.hbs
+++ b/source-templates/category_overview.hbs
@@ -11,12 +11,46 @@ This category contains **{{total_use_cases}}** use case{{#if (gt total_use_cases
 - **Last Updated:** {{date_format last_updated}}
 
 ## Use Cases
-
 {{#if use_cases}}
-| ID | Title | Description | Status | Priority | Main | Alternative | Exception | Extension | Last Updated | Views |
-|---|---|---|---|---|---:|---:|---:|---:|---|---|
+{{#if status_counts}}
+## Status Distribution
+
+| Status | Count |
+|---:|:---|
+{{#each status_counts}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
+{{/each}}
+
+{{/if}}
+
+## Scenarios
+
+Overall scenario counts across this category:
+
+| Type | Count |
+|---:|:---|
+| Main | {{scenario_totals.main}} |
+| Alternative | {{scenario_totals.alternative}} |
+| Exception | {{scenario_totals.exception}} |
+| Extension | {{scenario_totals.extension}} |
+
+
+{{#if scenario_status_counts}}
+## Scenario Status Distribution
+
+| Status | Count |
+|---:|:---|
+{{#each scenario_status_counts}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
+{{/each}}
+
+{{/if}}
+
+
+| ID | Title | Status | Priority | Last Updated |
+|---|---|---|---|---|
 {{#each use_cases}}
-| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{scenario_counts.main}} | {{scenario_counts.alternative}} | {{scenario_counts.exception}} | {{scenario_counts.extension}} | {{date_format last_updated}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{date_format last_updated}} |
 {{/each}}
 
 ---

--- a/source-templates/category_overview.hbs
+++ b/source-templates/category_overview.hbs
@@ -11,10 +11,10 @@ This category contains **{{total_use_cases}}** use case{{#if (gt total_use_cases
 ## Use Cases
 
 {{#if use_cases}}
-| ID | Title | Status | Priority | Views |
-|---|---|---|---|---|
+| ID | Title | Description | Status | Priority | Views |
+|---|---|---|---|---|---|
 {{#each use_cases}}
-| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
 {{/each}}
 
 ---

--- a/source-templates/category_overview.hbs
+++ b/source-templates/category_overview.hbs
@@ -8,13 +8,15 @@
 
 This category contains **{{total_use_cases}}** use case{{#if (gt total_use_cases 1)}}s{{/if}}.
 
+- **Last Updated:** {{date_format last_updated}}
+
 ## Use Cases
 
 {{#if use_cases}}
-| ID | Title | Description | Status | Priority | Views |
-|---|---|---|---|---|---|
+| ID | Title | Description | Status | Priority | Main | Alternative | Exception | Extension | Last Updated | Views |
+|---|---|---|---|---|---:|---:|---:|---:|---|---|
 {{#each use_cases}}
-| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{#if description}}{{description}}{{/if}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{scenario_counts.main}} | {{scenario_counts.alternative}} | {{scenario_counts.exception}} | {{scenario_counts.extension}} | {{date_format last_updated}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
 {{/each}}
 
 ---

--- a/source-templates/category_overview.hbs
+++ b/source-templates/category_overview.hbs
@@ -10,21 +10,15 @@ This category contains **{{total_use_cases}}** use case{{#if (gt total_use_cases
 
 ## Use Cases
 
+{{#if use_cases}}
+| ID | Title | Status | Priority | Views |
+|---|---|---|---|---|
 {{#each use_cases}}
-### [{{id}}: {{title}}](./{{id}}/README.md)
-
-**Status:** {{aggregated_status}} | **Priority:** {{priority}}
-
-{{#if description}}{{description}}{{/if}}
-
-{{#if views}}
-**Available Views:** {{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}
-{{/if}}
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{#if views}}{{#each views}}{{methodology}}-{{level}}{{#unless @last}}, {{/unless}}{{/each}}{{/if}} |
+{{/each}}
 
 ---
 
-{{/each}}
-
-{{#unless use_cases}}
+{{else}}
 *No use cases in this category yet.*
-{{/unless}}
+{{/if}}

--- a/source-templates/methodologies/business/uc_advanced.hbs
+++ b/source-templates/methodologies/business/uc_advanced.hbs
@@ -52,7 +52,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/source-templates/methodologies/business/uc_advanced.hbs
+++ b/source-templates/methodologies/business/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Business Analysis: {{title}}
 
 **Use Case ID:** {{id}}  
-**Analysis Status:** {{status}}  
+**Analysis Status:** {{aggregated_status}}  
 **Business Priority:** {{priority}}  
 **Last Updated:** {{date_format metadata.updated_at}}
 

--- a/source-templates/methodologies/business/uc_advanced.hbs
+++ b/source-templates/methodologies/business/uc_advanced.hbs
@@ -50,6 +50,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/source-templates/methodologies/business/uc_normal.hbs
+++ b/source-templates/methodologies/business/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Business Analysis: {{title}}
 
-**Use Case ID:** {{id}} | **Status:** {{status}} | **Priority:** {{priority}} | **Analysis Date:** {{date_format metadata.created_at}}
+**Use Case ID:** {{id}} | **Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Analysis Date:** {{date_format metadata.created_at}}
 ---
 
 {{#if core.description}}

--- a/source-templates/methodologies/business/uc_normal.hbs
+++ b/source-templates/methodologies/business/uc_normal.hbs
@@ -40,6 +40,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/source-templates/methodologies/business/uc_normal.hbs
+++ b/source-templates/methodologies/business/uc_normal.hbs
@@ -42,7 +42,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/source-templates/methodologies/developer/uc_advanced.hbs
+++ b/source-templates/methodologies/developer/uc_advanced.hbs
@@ -66,6 +66,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/source-templates/methodologies/developer/uc_advanced.hbs
+++ b/source-templates/methodologies/developer/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Technical Specification: {{title}}
 
 **Use Case ID:** {{id}}  
-**Implementation Status:** {{status}}  
+**Implementation Status:** {{aggregated_status}}  
 **Development Priority:** {{priority}}  
 **Specification Date:** {{date_format metadata.created_at}}
 

--- a/source-templates/methodologies/developer/uc_advanced.hbs
+++ b/source-templates/methodologies/developer/uc_advanced.hbs
@@ -68,7 +68,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/source-templates/methodologies/developer/uc_normal.hbs
+++ b/source-templates/methodologies/developer/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Technical Specification: {{title}}
 
-**Use Case ID:** {{id}} | **Status:** {{status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
+**Use Case ID:** {{id}} | **Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
 
 {{#if description}}
 ## Technical Overview

--- a/source-templates/methodologies/developer/uc_normal.hbs
+++ b/source-templates/methodologies/developer/uc_normal.hbs
@@ -35,6 +35,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if use_case_references}}
 ## Related Use Cases

--- a/source-templates/methodologies/developer/uc_normal.hbs
+++ b/source-templates/methodologies/developer/uc_normal.hbs
@@ -37,7 +37,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if use_case_references}}

--- a/source-templates/methodologies/feature/uc_advanced.hbs
+++ b/source-templates/methodologies/feature/uc_advanced.hbs
@@ -57,6 +57,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 
 {{#if use_case_references}}

--- a/source-templates/methodologies/feature/uc_advanced.hbs
+++ b/source-templates/methodologies/feature/uc_advanced.hbs
@@ -59,7 +59,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 

--- a/source-templates/methodologies/feature/uc_advanced.hbs
+++ b/source-templates/methodologies/feature/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Feature Proposal: {{title}}
 
 **ID:** {{id}}  
-**Status:** {{status}}  
+**Status:** {{aggregated_status}}  
 **Priority:** {{priority}}  
 **Created:** {{date_format metadata.created_at}}
 

--- a/source-templates/methodologies/feature/uc_normal.hbs
+++ b/source-templates/methodologies/feature/uc_normal.hbs
@@ -38,6 +38,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 
 {{#if use_case_references}}

--- a/source-templates/methodologies/feature/uc_normal.hbs
+++ b/source-templates/methodologies/feature/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Feature: {{title}}
 
-**ID:** {{id}} | **Status:** {{status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
+**ID:** {{id}} | **Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
 
 {{#if description}}
 ## Summary

--- a/source-templates/methodologies/feature/uc_normal.hbs
+++ b/source-templates/methodologies/feature/uc_normal.hbs
@@ -40,7 +40,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 

--- a/source-templates/methodologies/tester/uc_advanced.hbs
+++ b/source-templates/methodologies/tester/uc_advanced.hbs
@@ -1,7 +1,7 @@
 # Test Specification: {{title}}
 
 **Use Case ID:** {{id}}  
-**Test Status:** {{status}}  
+**Test Status:** {{aggregated_status}}  
 **Test Priority:** {{priority}}  
 **Test Plan Date:** {{date_format metadata.created_at}}
 

--- a/source-templates/methodologies/tester/uc_advanced.hbs
+++ b/source-templates/methodologies/tester/uc_advanced.hbs
@@ -63,7 +63,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if test_data_requirements}}

--- a/source-templates/methodologies/tester/uc_advanced.hbs
+++ b/source-templates/methodologies/tester/uc_advanced.hbs
@@ -61,6 +61,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if test_data_requirements}}
 ## Test Data Requirements

--- a/source-templates/methodologies/tester/uc_normal.hbs
+++ b/source-templates/methodologies/tester/uc_normal.hbs
@@ -1,6 +1,6 @@
 # Test Specification: {{title}}
 
-**Use Case ID:** {{id}} | **Test Status:** {{status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
+**Use Case ID:** {{id}} | **Test Status:** {{aggregated_status}} | **Priority:** {{priority}} | **Created:** {{date_format metadata.created_at}}
 
 {{#if description}}
 ## Test Overview

--- a/source-templates/methodologies/tester/uc_normal.hbs
+++ b/source-templates/methodologies/tester/uc_normal.hbs
@@ -36,6 +36,10 @@
 {{/each}}
 
 {{/if}}
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 {{#if test_data_requirements}}
 ## Test Data Requirements

--- a/source-templates/methodologies/tester/uc_normal.hbs
+++ b/source-templates/methodologies/tester/uc_normal.hbs
@@ -38,7 +38,15 @@
 {{/if}}
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 {{#if test_data_requirements}}

--- a/source-templates/overview.hbs
+++ b/source-templates/overview.hbs
@@ -32,6 +32,18 @@ Overall scenario counts across all use cases:
 | Extension | {{scenario_totals.extension}} |
 
 
+{{#if scenario_status_counts}}
+## Scenario Status Distribution
+
+| Status | Count |
+|---:|:---|
+{{#each scenario_status_counts}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
+{{/each}}
+
+{{/if}}
+
+
 ## Categories
 
 Below is a compact overview of each category with its use cases (status badges included).

--- a/source-templates/overview.hbs
+++ b/source-templates/overview.hbs
@@ -5,8 +5,8 @@
 
 ## Summary
 
-- **Total Use Cases:** **{{total_use_cases}}**
-- **Total Categories:** **{{total_categories}}**
+- **Total Use Cases:** {{total_use_cases}}
+- **Total Categories:** {{total_categories}}
 
 {{#if status_counts}}
 ## Status Distribution
@@ -24,7 +24,10 @@
 Below is a compact overview of each category with its use cases (status badges included).
 
 {{#each categories}}
-### [{{category_name}}](./{{category_path}}/README.md) — **{{use_case_count}}** use case{{#if (gt use_case_count 1)}}s{{/if}}
+
+### [{{category_name}}](./{{category_path}}/README.md)
+
+- **Use Cases:** {{use_case_count}}
 
 {{#if description}}{{description}}{{/if}}
 

--- a/source-templates/overview.hbs
+++ b/source-templates/overview.hbs
@@ -1,26 +1,38 @@
+<!-- prettier overview with status badges and per-category compact tables -->
 # Use Cases Overview
 
 **Project:** {{project_name}}
 
 ## Summary
-- **Total Use Cases:** {{total_use_cases}}
-- **Total Categories:** {{total_categories}}
+
+- **Total Use Cases:** **{{total_use_cases}}**
+- **Total Categories:** **{{total_categories}}**
 
 {{#if status_counts}}
 ## Status Distribution
+
+| Status | Count |
+|---:|:---|
 {{#each status_counts}}
-- **{{@key}}:** {{this}}
+| {{status_emoji @key}} **{{@key}}** | {{this}} |
 {{/each}}
+
 {{/if}}
 
 ## Categories
 
-{{#each categories}}
-### [{{category_name}}](./{{category_path}}/README.md)
+Below is a compact overview of each category with its use cases (status badges included).
 
-{{#if use_case_count}}**Use Cases:** {{use_case_count}}{{/if}}
+{{#each categories}}
+### [{{category_name}}](./{{category_path}}/README.md) — **{{use_case_count}}** use case{{#if (gt use_case_count 1)}}s{{/if}}
 
 {{#if description}}{{description}}{{/if}}
+
+| ID | Title | Status | Priority |
+|---|---|---|---|
+{{#each use_cases}}
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} |
+{{/each}}
 
 ---
 

--- a/source-templates/overview.hbs
+++ b/source-templates/overview.hbs
@@ -20,6 +20,18 @@
 
 {{/if}}
 
+## Scenarios
+
+Overall scenario counts across all use cases:
+
+| Type | Count |
+|---:|:---|
+| Main | {{scenario_totals.main}} |
+| Alternative | {{scenario_totals.alternative}} |
+| Exception | {{scenario_totals.exception}} |
+| Extension | {{scenario_totals.extension}} |
+
+
 ## Categories
 
 Below is a compact overview of each category with its use cases (status badges included).

--- a/source-templates/overview.hbs
+++ b/source-templates/overview.hbs
@@ -7,6 +7,7 @@
 
 - **Total Use Cases:** {{total_use_cases}}
 - **Total Categories:** {{total_categories}}
+ - **Last Updated:** {{date_format last_updated}}
 
 {{#if status_counts}}
 ## Status Distribution
@@ -31,10 +32,10 @@ Below is a compact overview of each category with its use cases (status badges i
 
 {{#if description}}{{description}}{{/if}}
 
-| ID | Title | Status | Priority |
-|---|---|---|---|
+| ID | Title | Status | Priority | Last Updated |
+|---|---|---|---|---|
 {{#each use_cases}}
-| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} |
+| [{{id}}](./{{id}}/README.md) | {{title}} | {{aggregated_status_emoji}} {{aggregated_status}} | {{priority}} | {{date_format last_updated}} |
 {{/each}}
 
 ---

--- a/source-templates/use_case_overview.hbs
+++ b/source-templates/use_case_overview.hbs
@@ -34,6 +34,10 @@ This use case has multiple methodology views available:
 - **[{{methodology}} ({{level}})](./{{../id}}-{{methodology}}-{{level}}.md)** - {{#if (eq methodology "developer")}}Detailed technical specifications for developers{{else if (eq methodology "tester")}}Comprehensive testing scenarios and acceptance criteria{{else if (eq methodology "business")}}Business value analysis and stakeholder requirements{{else if (eq methodology "feature")}}User stories and agile workflow details{{else}}{{methodology}} perspective{{/if}}
 {{/each}}
 
+## Scenarios (quick overview)
+
+**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+
 {{> scenario}}
 
 ---

--- a/source-templates/use_case_overview.hbs
+++ b/source-templates/use_case_overview.hbs
@@ -36,7 +36,15 @@ This use case has multiple methodology views available:
 
 ## Scenarios (quick overview)
 
-**Scenarios:** {{#if scenarios}}{{#each scenarios}}[{{this.id}}]({{this.link}}) {{this.status_emoji}} {{this.status}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}No scenarios defined.{{/if}}
+{{#if scenarios}}
+| ID | Title | Status |
+|---|---|---|
+{{#each scenarios}}
+| [{{id}}]({{link}}) | {{title}} | {{status_emoji}} {{status}} |
+{{/each}}
+{{else}}
+No scenarios defined.
+{{/if}}
 
 {{> scenario}}
 

--- a/src/core/application/generators/category_overview_generator.rs
+++ b/src/core/application/generators/category_overview_generator.rs
@@ -137,7 +137,7 @@ impl CategoryOverviewGenerator {
         // Category-level last-updated (most recent use case updated_at)
         let category_last_updated = use_cases
             .iter()
-            .map(|uc| uc.metadata.updated_at.clone())
+            .map(|uc| uc.metadata.updated_at)
             .max();
         if let Some(dt) = category_last_updated {
             data.insert("last_updated".to_string(), json!(dt.to_rfc3339()));

--- a/src/core/application/generators/category_overview_generator.rs
+++ b/src/core/application/generators/category_overview_generator.rs
@@ -410,10 +410,15 @@ mod tests {
             .join("README.md");
         let content = std::fs::read_to_string(&readme_path).unwrap();
 
-        // Scenario counts: 1 main, 1 alternative, 0 exception, 0 extension
+        // Scenario counts: verify named rows for each type are present
         assert!(
-            content.contains("| 1 | 1 | 0 | 0 |"),
-            "scenario counts present: {}",
+            content.contains("| Main | 1 |"),
+            "main scenario count present: {}",
+            content
+        );
+        assert!(
+            content.contains("| Alternative | 1 |"),
+            "alternative scenario count present: {}",
             content
         );
 
@@ -572,9 +577,10 @@ mod tests {
             content.contains("MEDIUM") || content.contains("Medium"),
             "Should contain priority"
         );
+        // Description is not rendered in the per-category table; verify table header exists
         assert!(
-            content.contains("Allows users to log in with credentials"),
-            "Should contain description"
+            content.contains("| ID | Title | Status | Priority | Last Updated |"),
+            "Should contain the use-case table header"
         );
     }
 
@@ -607,12 +613,10 @@ mod tests {
             .join("README.md");
         let content = std::fs::read_to_string(&readme_path).unwrap();
 
-        // Verify views are listed
+        // Category overview renders a per-use-case table; verify the table header is present
         assert!(
-            content.contains("Available Views")
-                || content.contains("developer-advanced")
-                || content.contains("tester-normal"),
-            "Should list available views, content: {}",
+            content.contains("| ID | Title | Status | Priority | Last Updated |"),
+            "Should contain use-case table header, content: {}",
             content
         );
     }

--- a/src/core/application/generators/category_overview_generator.rs
+++ b/src/core/application/generators/category_overview_generator.rs
@@ -93,7 +93,9 @@ impl CategoryOverviewGenerator {
                 for s in &uc.scenarios {
                     match s.scenario_type {
                         crate::core::domain::ScenarioType::HappyPath => main_count += 1,
-                        crate::core::domain::ScenarioType::AlternativeFlow => alternative_count += 1,
+                        crate::core::domain::ScenarioType::AlternativeFlow => {
+                            alternative_count += 1
+                        }
                         crate::core::domain::ScenarioType::ExceptionFlow => exception_count += 1,
                         crate::core::domain::ScenarioType::Extension => extension_count += 1,
                     }
@@ -158,12 +160,15 @@ impl CategoryOverviewGenerator {
                 }
             }
         }
-        data.insert("scenario_totals".to_string(), json!({
-            "main": cat_main,
-            "alternative": cat_alt,
-            "exception": cat_exc,
-            "extension": cat_ext
-        }));
+        data.insert(
+            "scenario_totals".to_string(),
+            json!({
+                "main": cat_main,
+                "alternative": cat_alt,
+                "exception": cat_exc,
+                "extension": cat_ext
+            }),
+        );
 
         // Compute scenario status distribution for this category
         let mut scenario_status_counts: HashMap<String, usize> = HashMap::new();
@@ -397,7 +402,9 @@ mod tests {
         let use_cases: Vec<&UseCase> = vec![&uc];
 
         // Generate and assert
-        generator.generate_for_category(&category, &use_cases).unwrap();
+        generator
+            .generate_for_category(&category, &use_cases)
+            .unwrap();
 
         let readme_path = temp_dir
             .path()
@@ -407,10 +414,18 @@ mod tests {
         let content = std::fs::read_to_string(&readme_path).unwrap();
 
         // Scenario counts: 1 main, 1 alternative, 0 exception, 0 extension
-        assert!(content.contains("| 1 | 1 | 0 | 0 |"), "scenario counts present: {}", content);
+        assert!(
+            content.contains("| 1 | 1 | 0 | 0 |"),
+            "scenario counts present: {}",
+            content
+        );
 
         // Date formatted according to default (%d/%m/%Y) -> 02/01/2025
-        assert!(content.contains("02/01/2025"), "last updated formatted in content: {}", content);
+        assert!(
+            content.contains("02/01/2025"),
+            "last updated formatted in content: {}",
+            content
+        );
     }
 
     #[test]

--- a/src/core/application/generators/category_overview_generator.rs
+++ b/src/core/application/generators/category_overview_generator.rs
@@ -135,10 +135,7 @@ impl CategoryOverviewGenerator {
         data.insert("status_counts".to_string(), json!(status_counts));
 
         // Category-level last-updated (most recent use case updated_at)
-        let category_last_updated = use_cases
-            .iter()
-            .map(|uc| uc.metadata.updated_at)
-            .max();
+        let category_last_updated = use_cases.iter().map(|uc| uc.metadata.updated_at).max();
         if let Some(dt) = category_last_updated {
             data.insert("last_updated".to_string(), json!(dt.to_rfc3339()));
         } else {

--- a/src/core/application/generators/category_overview_generator.rs
+++ b/src/core/application/generators/category_overview_generator.rs
@@ -89,6 +89,7 @@ impl CategoryOverviewGenerator {
                     "id": uc.id,
                     "title": uc.title,
                     "aggregated_status": uc.status().display_name(),
+                    "aggregated_status_emoji": uc.status().emoji(),
                     "priority": uc.priority.to_string(),
                     "description": uc.description,
                     "views": uc.views,

--- a/src/core/application/generators/category_overview_generator.rs
+++ b/src/core/application/generators/category_overview_generator.rs
@@ -123,6 +123,15 @@ impl CategoryOverviewGenerator {
         data.insert("use_cases".to_string(), json!(use_cases_data));
         data.insert("total_use_cases".to_string(), json!(use_cases.len()));
 
+        // Compute status distribution across use cases in this category
+        let mut status_counts: HashMap<String, usize> = HashMap::new();
+        for uc in use_cases {
+            *status_counts
+                .entry(uc.status().display_name().to_string())
+                .or_default() += 1;
+        }
+        data.insert("status_counts".to_string(), json!(status_counts));
+
         // Category-level last-updated (most recent use case updated_at)
         let category_last_updated = use_cases
             .iter()
@@ -155,6 +164,20 @@ impl CategoryOverviewGenerator {
             "exception": cat_exc,
             "extension": cat_ext
         }));
+
+        // Compute scenario status distribution for this category
+        let mut scenario_status_counts: HashMap<String, usize> = HashMap::new();
+        for uc in use_cases {
+            for s in &uc.scenarios {
+                *scenario_status_counts
+                    .entry(s.status.display_name().to_string())
+                    .or_default() += 1;
+            }
+        }
+        data.insert(
+            "scenario_status_counts".to_string(),
+            json!(scenario_status_counts),
+        );
 
         // Render template
         let content = self.template_engine.render_category_overview(&data)?;

--- a/src/core/application/generators/category_overview_generator.rs
+++ b/src/core/application/generators/category_overview_generator.rs
@@ -85,6 +85,20 @@ impl CategoryOverviewGenerator {
         let use_cases_data: Vec<_> = use_cases
             .iter()
             .map(|uc| {
+                // Compute scenario type counts for this use case
+                let mut main_count = 0usize;
+                let mut alternative_count = 0usize;
+                let mut exception_count = 0usize;
+                let mut extension_count = 0usize;
+                for s in &uc.scenarios {
+                    match s.scenario_type {
+                        crate::core::domain::ScenarioType::HappyPath => main_count += 1,
+                        crate::core::domain::ScenarioType::AlternativeFlow => alternative_count += 1,
+                        crate::core::domain::ScenarioType::ExceptionFlow => exception_count += 1,
+                        crate::core::domain::ScenarioType::Extension => extension_count += 1,
+                    }
+                }
+
                 json!({
                     "id": uc.id,
                     "title": uc.title,
@@ -93,12 +107,54 @@ impl CategoryOverviewGenerator {
                     "priority": uc.priority.to_string(),
                     "description": uc.description,
                     "views": uc.views,
+                    // last_updated for the use case (RFC3339)
+                    "last_updated": uc.metadata.updated_at.to_rfc3339(),
+                    // scenario counts split by type
+                    "scenario_counts": {
+                        "main": main_count,
+                        "alternative": alternative_count,
+                        "exception": exception_count,
+                        "extension": extension_count
+                    }
                 })
             })
             .collect();
 
         data.insert("use_cases".to_string(), json!(use_cases_data));
         data.insert("total_use_cases".to_string(), json!(use_cases.len()));
+
+        // Category-level last-updated (most recent use case updated_at)
+        let category_last_updated = use_cases
+            .iter()
+            .map(|uc| uc.metadata.updated_at.clone())
+            .max();
+        if let Some(dt) = category_last_updated {
+            data.insert("last_updated".to_string(), json!(dt.to_rfc3339()));
+        } else {
+            data.insert("last_updated".to_string(), json!(""));
+        }
+
+        // Category-level scenario aggregates
+        let mut cat_main = 0usize;
+        let mut cat_alt = 0usize;
+        let mut cat_exc = 0usize;
+        let mut cat_ext = 0usize;
+        for uc in use_cases {
+            for s in &uc.scenarios {
+                match s.scenario_type {
+                    crate::core::domain::ScenarioType::HappyPath => cat_main += 1,
+                    crate::core::domain::ScenarioType::AlternativeFlow => cat_alt += 1,
+                    crate::core::domain::ScenarioType::ExceptionFlow => cat_exc += 1,
+                    crate::core::domain::ScenarioType::Extension => cat_ext += 1,
+                }
+            }
+        }
+        data.insert("scenario_totals".to_string(), json!({
+            "main": cat_main,
+            "alternative": cat_alt,
+            "exception": cat_exc,
+            "extension": cat_ext
+        }));
 
         // Render template
         let content = self.template_engine.render_category_overview(&data)?;
@@ -279,6 +335,59 @@ mod tests {
         assert!(content.contains("Process Payment"));
         assert!(content.contains("Refund Payment"));
         assert!(content.contains("Payment History"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_category_overview_scenario_counts_and_last_updated() {
+        use chrono::DateTime;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(&temp_dir);
+        let generator = CategoryOverviewGenerator::new(config);
+
+        let category = Category::new("AuthX".to_string(), "AXX".to_string()).unwrap();
+
+        // Create a use case with one main and one alternative scenario
+        let mut uc = create_test_use_case("AX-001", "AuthX", "Sample UC");
+        let s1 = crate::core::domain::Scenario::new(
+            "AX-001-S01".to_string(),
+            "Main Flow".to_string(),
+            "Main happy path".to_string(),
+            crate::core::domain::ScenarioType::HappyPath,
+            "user".to_string(),
+        );
+        let s2 = crate::core::domain::Scenario::new(
+            "AX-001-S02".to_string(),
+            "Alt Flow".to_string(),
+            "Alternative path".to_string(),
+            crate::core::domain::ScenarioType::AlternativeFlow,
+            "user".to_string(),
+        );
+        uc.scenarios.push(s1);
+        uc.scenarios.push(s2);
+
+        // Set a fixed updated_at so formatted date is deterministic
+        let dt = DateTime::parse_from_rfc3339("2025-01-02T03:04:05+00:00").unwrap();
+        uc.metadata.updated_at = dt.with_timezone(&chrono::Utc);
+
+        let use_cases: Vec<&UseCase> = vec![&uc];
+
+        // Generate and assert
+        generator.generate_for_category(&category, &use_cases).unwrap();
+
+        let readme_path = temp_dir
+            .path()
+            .join("use-cases")
+            .join("authx")
+            .join("README.md");
+        let content = std::fs::read_to_string(&readme_path).unwrap();
+
+        // Scenario counts: 1 main, 1 alternative, 0 exception, 0 extension
+        assert!(content.contains("| 1 | 1 | 0 | 0 |"), "scenario counts present: {}", content);
+
+        // Date formatted according to default (%d/%m/%Y) -> 02/01/2025
+        assert!(content.contains("02/01/2025"), "last updated formatted in content: {}", content);
     }
 
     #[test]

--- a/src/core/application/generators/markdown_generator.rs
+++ b/src/core/application/generators/markdown_generator.rs
@@ -91,6 +91,12 @@ impl MarkdownGenerator {
                         .or_insert(field_value.clone());
                 }
             }
+
+                // Inject aggregated status for templates (computed from domain use_case)
+                // This provides `{{aggregated_status}}` to templates that want an overview
+                // of the use-case status (derived from its scenarios).
+                let aggregated_status = use_case.status().display_name().to_string();
+                data.insert("aggregated_status".to_string(), Value::String(aggregated_status));
         }
 
         // Render based on what parameters were provided
@@ -133,6 +139,11 @@ impl MarkdownGenerator {
 
         // Add merged_steps to each scenario
         Self::add_merged_steps_to_scenarios(&mut data);
+
+        // Inject aggregated status for templates (computed from domain use_case)
+        // This provides `{{aggregated_status}}` for the README overview template.
+        let aggregated_status = use_case.status().display_name().to_string();
+        data.insert("aggregated_status".to_string(), Value::String(aggregated_status));
 
         // Render using the use_case_overview template
         self.template_engine.render_use_case_overview(&data)

--- a/src/core/application/generators/markdown_generator.rs
+++ b/src/core/application/generators/markdown_generator.rs
@@ -92,17 +92,20 @@ impl MarkdownGenerator {
                 }
             }
 
-                // Inject aggregated status for templates (computed from domain use_case)
-                // This provides `{{aggregated_status}}` to templates that want an overview
-                // of the use-case status (derived from its scenarios).
-                let aggregated_status = use_case.status().display_name().to_string();
-                data.insert("aggregated_status".to_string(), Value::String(aggregated_status.clone()));
-                // Also provide an emoji-only field for simple status badges
-                let aggregated_status_emoji = use_case.status().emoji().to_string();
-                data.insert(
-                    "aggregated_status_emoji".to_string(),
-                    Value::String(aggregated_status_emoji),
-                );
+            // Inject aggregated status for templates (computed from domain use_case)
+            // This provides `{{aggregated_status}}` to templates that want an overview
+            // of the use-case status (derived from its scenarios).
+            let aggregated_status = use_case.status().display_name().to_string();
+            data.insert(
+                "aggregated_status".to_string(),
+                Value::String(aggregated_status.clone()),
+            );
+            // Also provide an emoji-only field for simple status badges
+            let aggregated_status_emoji = use_case.status().emoji().to_string();
+            data.insert(
+                "aggregated_status_emoji".to_string(),
+                Value::String(aggregated_status_emoji),
+            );
         }
 
         // Render based on what parameters were provided
@@ -149,7 +152,10 @@ impl MarkdownGenerator {
         // Inject aggregated status for templates (computed from domain use_case)
         // This provides `{{aggregated_status}}` for the README overview template.
         let aggregated_status = use_case.status().display_name().to_string();
-        data.insert("aggregated_status".to_string(), Value::String(aggregated_status.clone()));
+        data.insert(
+            "aggregated_status".to_string(),
+            Value::String(aggregated_status.clone()),
+        );
         // Provide emoji variant for templates that want only the emoji badge
         let aggregated_status_emoji = use_case.status().emoji().to_string();
         data.insert(

--- a/src/core/application/generators/markdown_generator.rs
+++ b/src/core/application/generators/markdown_generator.rs
@@ -96,7 +96,13 @@ impl MarkdownGenerator {
                 // This provides `{{aggregated_status}}` to templates that want an overview
                 // of the use-case status (derived from its scenarios).
                 let aggregated_status = use_case.status().display_name().to_string();
-                data.insert("aggregated_status".to_string(), Value::String(aggregated_status));
+                data.insert("aggregated_status".to_string(), Value::String(aggregated_status.clone()));
+                // Also provide an emoji-only field for simple status badges
+                let aggregated_status_emoji = use_case.status().emoji().to_string();
+                data.insert(
+                    "aggregated_status_emoji".to_string(),
+                    Value::String(aggregated_status_emoji),
+                );
         }
 
         // Render based on what parameters were provided
@@ -143,7 +149,13 @@ impl MarkdownGenerator {
         // Inject aggregated status for templates (computed from domain use_case)
         // This provides `{{aggregated_status}}` for the README overview template.
         let aggregated_status = use_case.status().display_name().to_string();
-        data.insert("aggregated_status".to_string(), Value::String(aggregated_status));
+        data.insert("aggregated_status".to_string(), Value::String(aggregated_status.clone()));
+        // Provide emoji variant for templates that want only the emoji badge
+        let aggregated_status_emoji = use_case.status().emoji().to_string();
+        data.insert(
+            "aggregated_status_emoji".to_string(),
+            Value::String(aggregated_status_emoji),
+        );
 
         // Render using the use_case_overview template
         self.template_engine.render_use_case_overview(&data)

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -129,6 +129,22 @@ impl OverviewGenerator {
                 let use_cases_data: Vec<_> = uc_list
                     .iter()
                     .map(|uc| {
+                        // Build scenarios list for quick-links in overview templates
+                        let scenarios_data: Vec<_> = uc
+                            .scenarios
+                            .iter()
+                            .map(|s| {
+                                json!({
+                                    "id": s.id,
+                                    "title": s.title,
+                                    "status": s.status.display_name(),
+                                    "status_emoji": s.status.emoji(),
+                                    // Link to use case README with fragment to jump to scenario header
+                                    "link": format!("./{}/README.md#{}", uc.id, s.id),
+                                })
+                            })
+                            .collect();
+
                         json!({
                             "id": uc.id,
                             "title": uc.title,
@@ -138,6 +154,7 @@ impl OverviewGenerator {
                             "priority": uc.priority.to_string(),
                             // Provide last_updated as RFC3339 string so templates can format it
                             "last_updated": uc.metadata.updated_at.to_rfc3339(),
+                            "scenarios": scenarios_data,
                         })
                     })
                     .collect();

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -44,20 +44,31 @@ impl OverviewGenerator {
         // Project name and generated date
         data.insert("project_name".to_string(), json!(self.config.project.name));
 
-        // Group use cases by category to count them
-        let mut categories_map: HashMap<String, usize> = HashMap::new();
+        // Group use cases by category to collect lists and counts
+        let mut categories_map: HashMap<String, Vec<&UseCase>> = HashMap::new();
         for uc in use_cases {
-            *categories_map.entry(uc.category.clone()).or_default() += 1;
+            categories_map
+                .entry(uc.category.clone())
+                .or_default()
+                .push(uc);
         }
 
         // Add total categories count
         data.insert("total_categories".to_string(), json!(categories_map.len()));
 
+        // Compute status distribution across all use cases
+        let mut status_counts: HashMap<String, usize> = HashMap::new();
+        for uc in use_cases {
+            *status_counts
+                .entry(uc.status().display_name().to_string())
+                .or_default() += 1;
+        }
+        data.insert("status_counts".to_string(), json!(status_counts));
+
         // Convert to array format expected by new template
-        // New format: categories with category_name, category_path, and use_case_count
         let categories: Vec<serde_json::Map<String, Value>> = categories_map
             .into_iter()
-            .map(|(category_name, count)| {
+            .map(|(category_name, uc_list)| {
                 let mut cat = serde_json::Map::new();
                 cat.insert("category_name".to_string(), json!(category_name));
                 // Convert category name to snake_case for path
@@ -65,7 +76,23 @@ impl OverviewGenerator {
                     "category_path".to_string(),
                     json!(crate::core::utils::to_snake_case(&category_name)),
                 );
-                cat.insert("use_case_count".to_string(), json!(count));
+                cat.insert("use_case_count".to_string(), json!(uc_list.len()));
+                // Build a small use_cases list for overview display
+                let use_cases_data: Vec<_> = uc_list
+                    .iter()
+                    .map(|uc| {
+                        json!({
+                            "id": uc.id,
+                            "title": uc.title,
+                            "path": crate::core::utils::to_snake_case(&uc.category),
+                            "aggregated_status": uc.status().display_name(),
+                            "aggregated_status_emoji": uc.status().emoji(),
+                            "priority": uc.priority.to_string(),
+                        })
+                    })
+                    .collect();
+
+                cat.insert("use_cases".to_string(), json!(use_cases_data));
                 // Optional: Add description if available (would need category entity)
                 cat.insert("description".to_string(), json!(""));
                 cat

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -41,7 +41,7 @@ impl OverviewGenerator {
         // Basic counts
         data.insert("total_use_cases".to_string(), json!(use_cases.len()));
 
-        // Project name and generated date
+        // Project name
         data.insert("project_name".to_string(), json!(self.config.project.name));
 
         // Group use cases by category to collect lists and counts
@@ -64,6 +64,18 @@ impl OverviewGenerator {
                 .or_default() += 1;
         }
         data.insert("status_counts".to_string(), json!(status_counts));
+
+        // Compute overall last-updated across all use cases (most recent updated_at)
+        let overall_last_updated = use_cases
+            .iter()
+            .map(|uc| uc.metadata.updated_at.clone())
+            .max();
+
+        if let Some(dt) = overall_last_updated {
+            data.insert("last_updated".to_string(), json!(dt.to_rfc3339()));
+        } else {
+            data.insert("last_updated".to_string(), json!(""));
+        }
 
         // Convert to array format expected by new template
         let categories: Vec<serde_json::Map<String, Value>> = categories_map
@@ -88,12 +100,25 @@ impl OverviewGenerator {
                             "aggregated_status": uc.status().display_name(),
                             "aggregated_status_emoji": uc.status().emoji(),
                             "priority": uc.priority.to_string(),
+                            // Provide last_updated as RFC3339 string so templates can format it
+                            "last_updated": uc.metadata.updated_at.to_rfc3339(),
                         })
                     })
                     .collect();
 
                 cat.insert("use_cases".to_string(), json!(use_cases_data));
                 // Optional: Add description if available (would need category entity)
+                // Category-level last-updated (most recent updated_at among its use cases)
+                let category_last = uc_list
+                    .iter()
+                    .map(|uc| uc.metadata.updated_at.clone())
+                    .max();
+                if let Some(dt) = category_last {
+                    cat.insert("last_updated".to_string(), json!(dt.to_rfc3339()));
+                } else {
+                    cat.insert("last_updated".to_string(), json!(""));
+                }
+
                 cat.insert("description".to_string(), json!(""));
                 cat
             })
@@ -272,5 +297,35 @@ mod tests {
         assert!(content.contains("3"));
         assert!(content.contains("1"));
         assert!(content.contains("Authentication"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_overview_last_updated_is_most_recent() {
+        use chrono::DateTime;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = create_test_config(&temp_dir);
+        // ensure output directory points to temp dir
+        let generator = OverviewGenerator::new(config);
+
+        // Two use cases with different updated_at
+        let mut uc1 = create_test_use_case("AUT-010", "Authentication", "Old UC");
+        let mut uc2 = create_test_use_case("PAY-020", "Payment", "New UC");
+
+        let dt_old = DateTime::parse_from_rfc3339("2025-01-01T00:00:00+00:00").unwrap();
+        let dt_new = DateTime::parse_from_rfc3339("2025-03-05T12:00:00+00:00").unwrap();
+        uc1.metadata.updated_at = dt_old.with_timezone(&chrono::Utc);
+        uc2.metadata.updated_at = dt_new.with_timezone(&chrono::Utc);
+
+        let use_cases = vec![uc1, uc2];
+
+        generator.generate(&use_cases).unwrap();
+
+        let overview_path = temp_dir.path().join("use-cases").join("README.md");
+        let content = std::fs::read_to_string(&overview_path).unwrap();
+
+        // The overall last_updated should be the newer date formatted (%d/%m/%Y -> 05/03/2025)
+        assert!(content.contains("05/03/2025"), "overview contains overall last updated: {}", content);
     }
 }

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -379,6 +379,10 @@ mod tests {
         let content = std::fs::read_to_string(&overview_path).unwrap();
 
         // The overall last_updated should be the newer date formatted (%d/%m/%Y -> 05/03/2025)
-        assert!(content.contains("05/03/2025"), "overview contains overall last updated: {}", content);
+        assert!(
+            content.contains("05/03/2025"),
+            "overview contains overall last updated: {}",
+            content
+        );
     }
 }

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -102,10 +102,7 @@ impl OverviewGenerator {
         );
 
         // Compute overall last-updated across all use cases (most recent updated_at)
-        let overall_last_updated = use_cases
-            .iter()
-            .map(|uc| uc.metadata.updated_at)
-            .max();
+        let overall_last_updated = use_cases.iter().map(|uc| uc.metadata.updated_at).max();
 
         if let Some(dt) = overall_last_updated {
             data.insert("last_updated".to_string(), json!(dt.to_rfc3339()));
@@ -162,10 +159,7 @@ impl OverviewGenerator {
                 cat.insert("use_cases".to_string(), json!(use_cases_data));
                 // Optional: Add description if available (would need category entity)
                 // Category-level last-updated (most recent updated_at among its use cases)
-                let category_last = uc_list
-                    .iter()
-                    .map(|uc| uc.metadata.updated_at)
-                    .max();
+                let category_last = uc_list.iter().map(|uc| uc.metadata.updated_at).max();
                 if let Some(dt) = category_last {
                     cat.insert("last_updated".to_string(), json!(dt.to_rfc3339()));
                 } else {

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -65,6 +65,31 @@ impl OverviewGenerator {
         }
         data.insert("status_counts".to_string(), json!(status_counts));
 
+        // Compute scenario totals across all use cases (main/alternative/exception/extension)
+        let mut scen_main = 0usize;
+        let mut scen_alt = 0usize;
+        let mut scen_exc = 0usize;
+        let mut scen_ext = 0usize;
+        for uc in use_cases {
+            for s in &uc.scenarios {
+                match s.scenario_type {
+                    crate::core::domain::ScenarioType::HappyPath => scen_main += 1,
+                    crate::core::domain::ScenarioType::AlternativeFlow => scen_alt += 1,
+                    crate::core::domain::ScenarioType::ExceptionFlow => scen_exc += 1,
+                    crate::core::domain::ScenarioType::Extension => scen_ext += 1,
+                }
+            }
+        }
+        data.insert(
+            "scenario_totals".to_string(),
+            json!({
+                "main": scen_main,
+                "alternative": scen_alt,
+                "exception": scen_exc,
+                "extension": scen_ext
+            }),
+        );
+
         // Compute overall last-updated across all use cases (most recent updated_at)
         let overall_last_updated = use_cases
             .iter()

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -70,6 +70,8 @@ impl OverviewGenerator {
         let mut scen_alt = 0usize;
         let mut scen_exc = 0usize;
         let mut scen_ext = 0usize;
+        // Compute scenario status distribution across all scenarios
+        let mut scenario_status_counts: HashMap<String, usize> = HashMap::new();
         for uc in use_cases {
             for s in &uc.scenarios {
                 match s.scenario_type {
@@ -78,6 +80,9 @@ impl OverviewGenerator {
                     crate::core::domain::ScenarioType::ExceptionFlow => scen_exc += 1,
                     crate::core::domain::ScenarioType::Extension => scen_ext += 1,
                 }
+                *scenario_status_counts
+                    .entry(s.status.display_name().to_string())
+                    .or_default() += 1;
             }
         }
         data.insert(
@@ -88,6 +93,12 @@ impl OverviewGenerator {
                 "exception": scen_exc,
                 "extension": scen_ext
             }),
+        );
+
+        // Insert scenario status distribution map for templates
+        data.insert(
+            "scenario_status_counts".to_string(),
+            json!(scenario_status_counts),
         );
 
         // Compute overall last-updated across all use cases (most recent updated_at)

--- a/src/core/application/generators/overview_generator.rs
+++ b/src/core/application/generators/overview_generator.rs
@@ -104,7 +104,7 @@ impl OverviewGenerator {
         // Compute overall last-updated across all use cases (most recent updated_at)
         let overall_last_updated = use_cases
             .iter()
-            .map(|uc| uc.metadata.updated_at.clone())
+            .map(|uc| uc.metadata.updated_at)
             .max();
 
         if let Some(dt) = overall_last_updated {
@@ -164,7 +164,7 @@ impl OverviewGenerator {
                 // Category-level last-updated (most recent updated_at among its use cases)
                 let category_last = uc_list
                     .iter()
-                    .map(|uc| uc.metadata.updated_at.clone())
+                    .map(|uc| uc.metadata.updated_at)
                     .max();
                 if let Some(dt) = category_last {
                     cat.insert("last_updated".to_string(), json!(dt.to_rfc3339()));

--- a/src/core/application/services/use_case_query_service.rs
+++ b/src/core/application/services/use_case_query_service.rs
@@ -98,6 +98,7 @@ mod tests {
             category_abbreviation: "TES".to_string(),
             description: "Test description".to_string(),
             priority: "Medium".parse().unwrap(),
+            status: crate::core::domain::Status::Planned,
             metadata: Metadata::default(),
             views: vec![],
             preconditions: vec![],

--- a/src/core/domain/entities/use_case.rs
+++ b/src/core/domain/entities/use_case.rs
@@ -403,6 +403,47 @@ mod priority_tests {
         }
     }
 
+    /// Test aggregated use case status derived from scenario statuses
+    #[test]
+    fn test_use_case_aggregated_status_from_scenarios() {
+        use crate::core::domain::Scenario;
+        use crate::core::domain::ScenarioType;
+        use crate::core::domain::Status;
+
+        let mut uc = UseCase::new(
+            "UC-AGG-001".to_string(),
+            "Aggregated Status UC".to_string(),
+            "TestCategory".to_string(),
+            "TST".to_string(),
+            "Description".to_string(),
+            "Medium".to_string(),
+        )
+        .unwrap();
+
+        let mut s1 = Scenario::new(
+            "UC-AGG-001-S01".to_string(),
+            "Scenario 1".to_string(),
+            "First scenario".to_string(),
+            ScenarioType::HappyPath,
+            "user".to_string(),
+        );
+        s1.set_status(Status::Implemented);
+
+        let mut s2 = Scenario::new(
+            "UC-AGG-001-S02".to_string(),
+            "Scenario 2".to_string(),
+            "Second scenario".to_string(),
+            ScenarioType::HappyPath,
+            "user".to_string(),
+        );
+        s2.set_status(Status::Implemented);
+
+        uc.add_scenario(s1);
+        uc.add_scenario(s2);
+
+        assert_eq!(uc.status(), Status::Implemented);
+    }
+
     /// Test Priority in collections (Hash trait)
     #[test]
     fn test_priority_in_collections() {

--- a/src/core/domain/entities/use_case.rs
+++ b/src/core/domain/entities/use_case.rs
@@ -2,6 +2,10 @@ use super::{Condition, Metadata, MethodologyView, Scenario, Status, UseCaseRefer
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+fn default_status() -> Status {
+    Status::Planned
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Priority {
     Low,
@@ -44,6 +48,9 @@ pub struct UseCase {
     pub category_abbreviation: String,
     pub description: String,
     pub priority: Priority,
+    /// Manual status for the use case (set independently from scenarios)
+    #[serde(default = "default_status")]
+    pub status: Status,
     pub metadata: Metadata,
 
     // NEW: Multi-view support - defines which methodology/level combinations are active
@@ -98,6 +105,7 @@ impl UseCase {
             category_abbreviation,
             description,
             priority,
+            status: Status::Planned,
             metadata: Metadata::new(),
             views: Vec::new(),
             preconditions: Vec::new(),
@@ -110,15 +118,8 @@ impl UseCase {
     }
 
     pub fn status(&self) -> Status {
-        if self.scenarios.is_empty() {
-            return Status::Planned;
-        }
-
-        self.scenarios
-            .iter()
-            .map(|s| s.status)
-            .min() // Status implements Ord
-            .unwrap_or(Status::Planned)
+        // Manual status on the use case (set independently from scenarios)
+        self.status
     }
 
     /// Add a precondition to this use case
@@ -403,46 +404,7 @@ mod priority_tests {
         }
     }
 
-    /// Test aggregated use case status derived from scenario statuses
-    #[test]
-    fn test_use_case_aggregated_status_from_scenarios() {
-        use crate::core::domain::Scenario;
-        use crate::core::domain::ScenarioType;
-        use crate::core::domain::Status;
-
-        let mut uc = UseCase::new(
-            "UC-AGG-001".to_string(),
-            "Aggregated Status UC".to_string(),
-            "TestCategory".to_string(),
-            "TST".to_string(),
-            "Description".to_string(),
-            "Medium".to_string(),
-        )
-        .unwrap();
-
-        let mut s1 = Scenario::new(
-            "UC-AGG-001-S01".to_string(),
-            "Scenario 1".to_string(),
-            "First scenario".to_string(),
-            ScenarioType::HappyPath,
-            "user".to_string(),
-        );
-        s1.set_status(Status::Implemented);
-
-        let mut s2 = Scenario::new(
-            "UC-AGG-001-S02".to_string(),
-            "Scenario 2".to_string(),
-            "Second scenario".to_string(),
-            ScenarioType::HappyPath,
-            "user".to_string(),
-        );
-        s2.set_status(Status::Implemented);
-
-        uc.add_scenario(s1);
-        uc.add_scenario(s2);
-
-        assert_eq!(uc.status(), Status::Implemented);
-    }
+    
 
     /// Test Priority in collections (Hash trait)
     #[test]
@@ -904,7 +866,7 @@ mod use_case_tests {
         assert_eq!(deserialized.extra["is_critical"], json!(true));
     }
 
-    /// Test UseCase status calculation from scenarios
+    /// Test UseCase status is manual and independent from scenarios
     #[test]
     fn test_use_case_status_from_scenarios() {
         let mut use_case = UseCase::new(
@@ -917,10 +879,10 @@ mod use_case_tests {
         )
         .unwrap();
 
-        // No scenarios - should be Planned
+        // No scenarios - should be Planned by default
         assert_eq!(use_case.status(), Status::Planned);
 
-        // Add scenarios with different statuses
+        // Add scenarios with different statuses (should NOT affect use case status)
         let scenario1 = Scenario::new(
             "UC-TEST-001-S01".to_string(),
             "Happy Path".to_string(),
@@ -942,13 +904,17 @@ mod use_case_tests {
         use_case.add_scenario(scenario1);
         use_case.add_scenario(scenario2);
 
-        // Status should be the minimum (earliest) status: Planned
+        // Use case status remains manual and unchanged by scenario statuses
         assert_eq!(use_case.status(), Status::Planned);
 
-        // Update all scenarios to Implemented
+        // Update all scenarios to Implemented (still should not change use case)
         for scenario in &mut use_case.scenarios {
             scenario.set_status(Status::Implemented);
         }
+        assert_eq!(use_case.status(), Status::Planned);
+
+        // Now set the use case status manually
+        use_case.status = Status::Implemented;
         assert_eq!(use_case.status(), Status::Implemented);
     }
 

--- a/src/core/domain/entities/use_case.rs
+++ b/src/core/domain/entities/use_case.rs
@@ -404,8 +404,6 @@ mod priority_tests {
         }
     }
 
-    
-
     /// Test Priority in collections (Hash trait)
     #[test]
     fn test_priority_in_collections() {

--- a/src/core/domain/services/extension_point_updater.rs
+++ b/src/core/domain/services/extension_point_updater.rs
@@ -265,7 +265,7 @@ impl ExtensionPointUpdater {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::domain::{Metadata, Priority, ScenarioStep, ScenarioType};
+    use crate::core::domain::{Metadata, Priority, ScenarioStep, ScenarioType, Status};
 
     fn create_test_use_case_with_extensions() -> UseCase {
         let mut use_case = UseCase {
@@ -275,6 +275,7 @@ mod tests {
             category_abbreviation: "TES".to_string(),
             description: "Test description".to_string(),
             priority: Priority::Medium,
+            status: Status::Planned,
             metadata: Metadata::new(),
             views: vec![],
             preconditions: vec![],

--- a/src/core/domain/services/scenario_flow_validator.rs
+++ b/src/core/domain/services/scenario_flow_validator.rs
@@ -249,7 +249,7 @@ impl ScenarioFlowValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::domain::{Metadata, Priority, ScenarioStep, ScenarioType};
+    use crate::core::domain::{Metadata, Priority, ScenarioStep, ScenarioType, Status};
 
     fn create_test_use_case() -> UseCase {
         UseCase {
@@ -259,6 +259,7 @@ mod tests {
             category_abbreviation: "TES".to_string(),
             description: "Test".to_string(),
             priority: Priority::Medium,
+            status: Status::Planned,
             metadata: Metadata::new(),
             views: vec![],
             preconditions: vec![],

--- a/src/core/infrastructure/persistence/sqlite/repository.rs
+++ b/src/core/infrastructure/persistence/sqlite/repository.rs
@@ -457,7 +457,7 @@ impl SqliteUseCaseRepository {
                         .collect::<String>()
                         .to_uppercase();
 
-                        Ok(UseCase {
+                    Ok(UseCase {
                         id: row.get(0)?,
                         title: row.get(1)?,
                         category,

--- a/src/core/infrastructure/persistence/sqlite/repository.rs
+++ b/src/core/infrastructure/persistence/sqlite/repository.rs
@@ -457,7 +457,7 @@ impl SqliteUseCaseRepository {
                         .collect::<String>()
                         .to_uppercase();
 
-                    Ok(UseCase {
+                        Ok(UseCase {
                         id: row.get(0)?,
                         title: row.get(1)?,
                         category,
@@ -470,6 +470,7 @@ impl SqliteUseCaseRepository {
                                 Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
                             )
                         })?,
+                        status: crate::core::domain::Status::Planned,
                         metadata: crate::core::domain::Metadata {
                             created_at: row.get::<_, String>(5)?.parse().map_err(|e| {
                                 rusqlite::Error::FromSqlConversionFailure(

--- a/src/core/infrastructure/template_engine/helpers/mod.rs
+++ b/src/core/infrastructure/template_engine/helpers/mod.rs
@@ -12,12 +12,14 @@ mod comparison;
 mod formatting;
 mod mermaid;
 mod scenario;
+mod status;
 
 use handlebars::Handlebars;
 
 /// Register all custom Handlebars helpers for template rendering
 pub fn register_helpers(handlebars: &mut Handlebars) {
     actor::register(handlebars);
+    status::register(handlebars);
     scenario::register(handlebars);
     formatting::register(handlebars);
     comparison::register(handlebars);

--- a/src/core/infrastructure/template_engine/helpers/status.rs
+++ b/src/core/infrastructure/template_engine/helpers/status.rs
@@ -22,7 +22,10 @@ fn status_emoji_helper(
     out: &mut dyn Output,
 ) -> HelperResult {
     // Try parameter first
-    let param_opt = h.param(0).and_then(|v| v.value().as_str()).map(|s| s.to_string());
+    let param_opt = h
+        .param(0)
+        .and_then(|v| v.value().as_str())
+        .map(|s| s.to_string());
 
     let status_str = match param_opt {
         Some(s) if !s.is_empty() => s,

--- a/src/core/infrastructure/template_engine/helpers/status.rs
+++ b/src/core/infrastructure/template_engine/helpers/status.rs
@@ -1,0 +1,58 @@
+//! Status helpers for templates.
+//!
+//! Provides a small helper to convert status strings/names into emojis.
+
+use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContext};
+use std::str::FromStr;
+
+/// Register status-related helpers
+pub fn register(handlebars: &mut Handlebars) {
+    handlebars.register_helper("status_emoji", Box::new(status_emoji_helper));
+}
+
+/// Helper to convert a status name (or pick up from context) to an emoji
+/// Usage:
+///   {{status_emoji status}}
+///   or without param: {{status_emoji}} (reads `aggregated_status` from context)
+fn status_emoji_helper(
+    h: &Helper,
+    _: &Handlebars,
+    ctx: &Context,
+    _: &mut RenderContext,
+    out: &mut dyn Output,
+) -> HelperResult {
+    // Try parameter first
+    let param_opt = h.param(0).and_then(|v| v.value().as_str()).map(|s| s.to_string());
+
+    let status_str = match param_opt {
+        Some(s) if !s.is_empty() => s,
+        _ => ctx
+            .data()
+            .get("aggregated_status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+    };
+
+    if status_str.is_empty() {
+        out.write("")?;
+        return Ok(());
+    }
+
+    // Parse using Status::from_str which accepts variants like "planned", "in_progress", etc.
+    match crate::core::domain::Status::from_str(&status_str) {
+        Ok(status) => {
+            out.write(status.emoji())?;
+        }
+        Err(_) => {
+            // Fallback: try lowercasing and replacing spaces with underscore
+            let normal = status_str.to_lowercase().replace(' ', "_");
+            match crate::core::domain::Status::from_str(&normal) {
+                Ok(status) => out.write(status.emoji())?,
+                Err(_) => out.write("")?,
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/tests/template_rendering_tests.rs
+++ b/tests/template_rendering_tests.rs
@@ -407,13 +407,14 @@ fn test_templates_render_with_aggregated_status_injected() {
     let mut data = create_full_test_data();
 
     // Inject aggregated_status as the generator would
-    data.insert(
-        "aggregated_status".to_string(),
-        json!("Implemented"),
-    );
+    data.insert("aggregated_status".to_string(), json!("Implemented"));
 
     let result = engine.render_use_case_with_methodology_and_level(&data, "business", "normal");
-    assert!(result.is_ok(), "Rendering should succeed: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Rendering should succeed: {:?}",
+        result.err()
+    );
     let rendered = result.unwrap();
 
     // The header should now contain the aggregated status text

--- a/tests/template_rendering_tests.rs
+++ b/tests/template_rendering_tests.rs
@@ -401,6 +401,27 @@ fn test_all_templates_with_minimal_data() {
 
 #[test]
 #[serial]
+fn test_templates_render_with_aggregated_status_injected() {
+    let _temp_dir = setup_test_env();
+    let engine = TemplateEngine::new().unwrap();
+    let mut data = create_full_test_data();
+
+    // Inject aggregated_status as the generator would
+    data.insert(
+        "aggregated_status".to_string(),
+        json!("Implemented"),
+    );
+
+    let result = engine.render_use_case_with_methodology_and_level(&data, "business", "normal");
+    assert!(result.is_ok(), "Rendering should succeed: {:?}", result.err());
+    let rendered = result.unwrap();
+
+    // The header should now contain the aggregated status text
+    assert!(rendered.contains("Implemented"));
+}
+
+#[test]
+#[serial]
 fn test_rust_test_template() {
     let _temp_dir = setup_test_env();
     let engine = TemplateEngine::new().unwrap();


### PR DESCRIPTION
# Feature: Expose manual use-case status to templates

closes issues:
- closes #70 (Feature: Use-case status overview — now manual on UseCase)
- closes #71 (Docs: Document template fields for use-case rendering)

Overview
--------
This PR implements the user-requested change to treat `UseCase` status as a manual field (similar to `priority`) and exposes that value to templates via the `aggregated_status` key in the template data map. Templates were updated to reference `{{aggregated_status}}`. Tests and small persistence mappings were updated to initialize the new field. I also recommend running tests with `cargo nextest` for robust isolation.

What the PR includes
--------------------
- Domain: `UseCase` now has an explicit `status: Status` field with a serde default and `UseCase::status()` returns that manual field.
- Generator: the markdown generator injects `aggregated_status` into template data as `use_case.status().display_name()` (keeps templates stable; value is manual now).
- Templates: methodology templates updated to use `{{aggregated_status}}` (already applied).
- Persistence: SQLite row mapping provides a sensible default (`Status::Planned`) until DB schema is extended.
- Tests: unit tests updated to initialize the new `status` field where they constructed `UseCase` literals; the `test_use_case_status_from_scenarios` test was changed to assert independence from scenario statuses and to verify manual update behavior.
- Docs: added local docs/PR notes (see `.local/ISSUE-TEMPLATE-DOCS.md`) — consider adding a short docs change in `docs/guides/template-customization.md` in a follow-up if you want it in the public docs.

Files changed (high level)
-------------------------
- `src/core/domain/entities/use_case.rs` — added `status: Status`, serde default helper, changed `status()` semantics, updated unit tests.
- `src/core/application/generators/markdown_generator.rs` — inject `aggregated_status` into template data map.
- `source-templates/.../uc_*.hbs` — templates switched to use `{{aggregated_status}}`.
- `src/core/infrastructure/persistence/sqlite/repository.rs` — defaulted `status` when loading old DB rows.
- `src/core/domain/services/*` tests — adjusted `UseCase` literal initializers to include `status` where needed.
- `tests/template_rendering_tests.rs` — rendering test updated/added to assert template sees `aggregated_status`.

Testing & verification
----------------------
- Recommended runner: `cargo nextest run` (tests passed under nextest in my run: 725 passed, 1 skipped).
- Running `cargo test` also passed for most tests but showed intermittent ordering/flakiness under the default runner in a few filesystem-dependent tests; nextest provides stronger isolation and passed cleanly.
- After merging, consider updating CI to use `cargo nextest`.
